### PR TITLE
Completed RapidAPI integration in the Home Screen

### DIFF
--- a/components/common/cards/nearby/NearbyJobCard.jsx
+++ b/components/common/cards/nearby/NearbyJobCard.jsx
@@ -1,14 +1,32 @@
-import React from 'react'
-import { View, Text } from 'react-native'
+import { View, Text, TouchableOpacity, Image } from "react-native";
+// styles
+import styles from "./nearbyjobcard.style";
+// utils
+import { checkImageURL } from "../../../../utils";
 
-import styles from './nearbyjobcard.style'
-
-const NearbyJobCard = () => {
+const NearbyJobCard = ({ job, handleNavigate }) => {
   return (
-    <View>
-      <Text>NearbyJobCard</Text>
-    </View>
-  )
-}
+    <TouchableOpacity style={styles.container} onPress={handleNavigate}>
+      <TouchableOpacity style={styles.logoContainer}>
+        <Image
+          source={{
+            uri: checkImageURL(job.employer_logo)
+              ? job.employer_logo
+              : "https://t4.ftcdn.net/jpg/05/05/61/73/360_F_505617309_NN1CW7diNmGXJfMicpY9eXHKV4sqzO5H.jpg",
+          }}
+          resizeMode="contain"
+          style={styles.logoImage}
+        />
+      </TouchableOpacity>
 
-export default NearbyJobCard
+      <View style={styles.textContainer}>
+        <Text style={styles.jobName} numberOfLines={1}>
+          {job.job_title}
+        </Text>
+        <Text style={styles.jobType}>{job.job_employment_type}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default NearbyJobCard;

--- a/components/common/cards/nearby/nearbyjobcard.style.js
+++ b/components/common/cards/nearby/nearbyjobcard.style.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  logImage: {
+  logoImage: {
     width: "70%",
     height: "70%",
   },

--- a/components/common/cards/popular/PopularJobCard.jsx
+++ b/components/common/cards/popular/PopularJobCard.jsx
@@ -1,14 +1,38 @@
-import React from 'react'
-import { View, Text } from 'react-native'
+import { View, Text, TouchableOpacity, Image } from "react-native";
+// styles
+import styles from "./popularjobcard.style";
+// utils
+import { checkImageURL } from "../../../../utils";
 
-import styles from './popularjobcard.style'
-
-const PopularJobCard = () => {
+const PopularJobCard = ({ item, selectedJob, handleCardPress }) => {
   return (
-    <View>
-      <Text>PopularJobCard</Text>
-    </View>
-  )
-}
+    <TouchableOpacity
+      style={styles.container(selectedJob, item)}
+      onPress={() => handleCardPress(item)}
+    >
+      <TouchableOpacity style={styles.logoContainer(selectedJob, item)}>
+        <Image
+          source={{
+            uri: checkImageURL(item?.employer_logo)
+              ? item.employer_logo
+              : "https://t4.ftcdn.net/jpg/05/05/61/73/360_F_505617309_NN1CW7diNmGXJfMicpY9eXHKV4sqzO5H.jpg",
+          }}
+          resizeMode="contain"
+          style={styles.logoImage}
+        />
+      </TouchableOpacity>
+      <Text style={styles.companyName} numberOfLines={1}>
+        {item.employer_name}
+      </Text>
 
-export default PopularJobCard
+      <View style={styles.infoContainer}>
+        <Text style={styles.jobName(selectedJob, item)} numberOfLines={1}>
+          {item.job_title}
+        </Text>
+        <Text style={styles.location}>{item.job_country}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default PopularJobCard;

--- a/components/home/nearby/Nearbyjobs.jsx
+++ b/components/home/nearby/Nearbyjobs.jsx
@@ -1,14 +1,48 @@
-import React from 'react'
-import { View, Text } from 'react-native'
-
-import styles from './nearbyjobs.style'
+import { View, Text, TouchableOpacity, ActivityIndicator } from "react-native";
+import { useRouter } from "expo-router";
+// components
+import NearbyJobCard from "../../common/cards/nearby/NearbyJobCard";
+// hooks
+import useFetch from "../../../hook/useFetch";
+// constants
+import { COLORS } from "../../../constants";
+// styles
+import styles from "./nearbyjobs.style";
 
 const Nearbyjobs = () => {
-  return (
-    <View>
-      <Text>Nearbyjobs</Text>
-    </View>
-  )
-}
+  const router = useRouter();
 
-export default Nearbyjobs
+  const { data, isLoading, error } = useFetch("search", {
+    query: "React developer",
+    num_pages: 1,
+  });
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Nearby jobs</Text>
+        <TouchableOpacity>
+          <Text style={styles.headerBtn}>Show all</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.cardsContainer}>
+        {isLoading ? (
+          <ActivityIndicator size="large" color={COLORS.primary} />
+        ) : error ? (
+          <Text>Something went wrong.</Text>
+        ) : (
+          data?.map((job) => (
+            <NearbyJobCard
+              job={job}
+              key={`nearby-job-${job?.job_id}`}
+              handleNavigate={() => router.push(`/job-details/${job.job_id}`)}
+            />
+          ))
+        )}
+      </View>
+    </View>
+  );
+};
+
+export default Nearbyjobs;

--- a/components/home/popular/Popularjobs.jsx
+++ b/components/home/popular/Popularjobs.jsx
@@ -9,6 +9,8 @@ import {
 import { useRouter } from "expo-router";
 // components
 import PopularJobCard from "../../common/cards/popular/PopularJobCard";
+// hooks
+import useFetch from "../../../hook/useFetch";
 // constants
 import { COLORS, SIZES } from "../../../constants";
 // styles
@@ -16,8 +18,18 @@ import styles from "./popularjobs.style";
 
 const Popularjobs = () => {
   const router = useRouter();
-  const isLoading = false;
-  const error = false;
+
+  const { data, isLoading, error } = useFetch("search", {
+    query: "React developer",
+    num_pages: 1,
+  });
+
+  const [selectedJob, setSelectedJob] = useState();
+
+  const handlePressCard = (item) => {
+    router.push(`/job-details/${item.job_id}`);
+    setSelectedJob(item.job_id);
+  };
 
   return (
     <View style={styles.container}>
@@ -35,8 +47,14 @@ const Popularjobs = () => {
           <Text>Something went wrong.</Text>
         ) : (
           <FlatList
-            data={[1, 2, 3, 4, 5, 6, 7, 8]}
-            renderItem={({ item }) => <PopularJobCard item={item} />}
+            data={data}
+            renderItem={({ item }) => (
+              <PopularJobCard
+                item={item}
+                selectedJob={selectedJob}
+                handleCardPress={handlePressCard}
+              />
+            )}
             keyExtractor={(item) => item?.job_id}
             contentContainerStyle={{ columnGap: SIZES.medium }}
             horizontal

--- a/hook/useFetch.js
+++ b/hook/useFetch.js
@@ -1,8 +1,5 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
-import { RAPID_API_KEY } from "@env";
-
-const rapidApiKey = RAPID_API_KEY;
 
 const useFetch = (endpoint, query) => {
   const [data, setData] = useState([]);
@@ -11,12 +8,12 @@ const useFetch = (endpoint, query) => {
 
   const options = {
     method: 'GET',
-    url: `https://jsearch.p.rapidapi.com/search/${endpoint}`,
-    params: { ...query },
+    url: `https://jsearch.p.rapidapi.com/${endpoint}`,
     headers: {
-      'X-RapidAPI-Key': rapidApiKey,
+      'X-RapidAPI-Key': 'cdbf4f4089msh20ec02a3150b88ep10a97cjsn2fc33553a816',
       'X-RapidAPI-Host': 'jsearch.p.rapidapi.com'
-    }
+    },
+    params: { ...query },
   };
 
   const fetchData = async () => {
@@ -44,4 +41,7 @@ const useFetch = (endpoint, query) => {
     fetchData();
   }
 
+  return { data, isLoading, error, refetch };
 }
+
+export default useFetch;

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,7 @@
+export const checkImageURL = (url) => {
+  if (!url) return false
+  else {
+    const pattern = new RegExp('^https?:\\/\\/.+\\.(png|jpg|jpeg|bmp|gif|webp)$', 'i');
+    return pattern.test(url);
+  }
+};


### PR DESCRIPTION
- **returned data** - at the bottom of our `useFetch.js` file we can return an object that's going to contain (`data`, `isLoading`, `error`, `refetch`)
- after that we can _utilize_ this function from within our **popular** and **nearby** jobs on the **Home** Screen
- populated **Popularjob** section with informations from previously created `PopularJobCard`
- made _horizontal_ scroll on our Popular Jobs
- called `useFetch()` hook and fetch **RapidAPI** _search_ endpoint
- made a same thing with **Nearby Jobs** except that now it is not a _horizontal_ `FlatList `but a _vertical_ data rendering